### PR TITLE
Release 1.0.4

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -210,8 +210,8 @@ defined with some timeout for performance reasons.
 The `language.js` goes like this:
 
 1. Define the constant `languages` with translated texts for each language.
-2. Check the URL query variable "lang". If it exists and it's a known language, use it, otherwise use
-Czech.
+2. Check the URL query variable "lang". If it exists and it's a known language, use it, otherwise
+use Czech.
 3. Create the language switcher content.
 4. Replace all texts in the DOM with translated texts.
 

--- a/README.md
+++ b/README.md
@@ -20,18 +20,35 @@ Main advantages:
 1. Clone this repo somewhere inside your webserver root.
 2. That's it.
 
-Unfortunately, you cannot play the game by just opening the HTML file in a browser, since modern browsers have [CSP rules](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) for `file` protocol that block CSS and/or JS files ("inlining" styles/scripts won't work as well).
+Unfortunately, you cannot play the game by just opening the HTML file in a browser, since modern
+browsers have [CSP rules](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) for `file`
+protocol that block CSS and/or JS files ("inlining" styles/scripts won't work as well).
 
 There are some simple web server solutions out there that work out-of-the-box and can be used for
-local playing.
+local playing. One for example is [lighttpd](https://redmine.lighttpd.net/projects/lighttpd), for
+which you can use this minimal config and then just spawn a local web server for it via
+`lighttpd -D -f lighttpd.conf`.
 
-If you want to just try playing the current version, go to [https://tommander.cz/mahjongg/](https://tommander.cz/mahjongg/).
+```
+server.document-root = "/path/to/mahjongg/"
+server.port = 80
+index-file.names = ( "dev.html" )
+mimetype.assign = (
+  ".html" => "text/html",
+  ".js" => "application/x-javascript",
+  ".css" => "text/css"
+)
+```
+
+If you want to just try playing the current version, go to
+[https://tommander.cz/mahjongg/](https://tommander.cz/mahjongg/).
 
 ## Game Rules
 
 You have 144 tiles that are placed in a predefined "turtle" shape.
 
-Your goal is to pick pairs of tiles with an identical symbol (or any two Flower/Season) until there is no block left on the board.
+Your goal is to pick pairs of tiles with an identical symbol (or any two Flower/Season) until there
+is no block left on the board.
 
 You can only pick a block that:
 
@@ -78,6 +95,9 @@ I'll be very thankful if you:
 
 ## License
 
-[Mahjongg Solitaire](https://github.com/tommander/mahjongg) by [Tomáš Rajnoha](https://tommander.cz) is marked [CC0 1.0](LICENSE).
+[Mahjongg Solitaire](https://github.com/tommander/mahjongg) by [Tomáš Rajnoha](https://tommander.cz)
+is marked [CC0 1.0](LICENSE).
 
-[Background photo](https://get.pxhere.com/photo/architecture-bridge-river-jungle-garden-waterway-rainforest-china-rural-area-arch-bridge-leshan-1166576.jpg) from [Pxhere](https://pxhere.com/ko/photo/1166576) is also marked [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/).
+[Background photo](https://get.pxhere.com/photo/architecture-bridge-river-jungle-garden-waterway-rainforest-china-rural-area-arch-bridge-leshan-1166576.jpg)
+from [Pxhere](https://pxhere.com/ko/photo/1166576) is also marked
+[CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/dev.html
+++ b/dev.html
@@ -13,6 +13,7 @@
 		<button type="button" class="newGame"><span aria-hidden="true">🆕</span><span class="visually-hidden">Nová hra</span></button>
 		<button type="button" id="helpButton"><span aria-hidden="true">❓</span><span class="visually-hidden">Nápověda</span></button>
 		<button type="button" id="beginnerButton"><span aria-hidden="true">🧑‍🎓</span><span class="visually-hidden">Zvýraznění</span></button>
+		<button type="button" id="reshuffleButton"><span aria-hidden="true">↺</span><span class="visually-hidden">Zamíchat</span></button>
 		<button type="button" id="undoButton"><span aria-hidden="true">↶</span><span class="visually-hidden">Zpět</span></button>
 		<button type="button" id="redoButton"><span aria-hidden="true">↷</span><span class="visually-hidden">Vpřed</span></button>
 		<label id="language-switcher-label" for="language-switcher">Jazyk:</label>

--- a/dev.html
+++ b/dev.html
@@ -10,11 +10,11 @@
 	<div class="panel" id="toppanel">
 		<div id="points" aria-label="Body">0</div>
 		<div id="time" aria-label="Uběhlý čas">0:00</div>
-		<button type="button" class="newGame">Nová hra</button>
-		<button type="button" id="helpButton">Nápověda</button>
-		<button type="button" id="beginnerButton">Zvýraznění</button>
-		<button type="button" id="undoButton">Zpět</button>
-		<button type="button" id="redoButton">Vpřed</button>
+		<button type="button" class="newGame"><span aria-hidden="true">🆕</span><span class="visually-hidden">Nová hra</span></button>
+		<button type="button" id="helpButton"><span aria-hidden="true">❓</span><span class="visually-hidden">Nápověda</span></button>
+		<button type="button" id="beginnerButton"><span aria-hidden="true">🧑‍🎓</span><span class="visually-hidden">Zvýraznění</span></button>
+		<button type="button" id="undoButton"><span aria-hidden="true">↶</span><span class="visually-hidden">Zpět</span></button>
+		<button type="button" id="redoButton"><span aria-hidden="true">↷</span><span class="visually-hidden">Vpřed</span></button>
 		<label id="language-switcher-label" for="language-switcher">Jazyk:</label>
 		<select id="language-switcher"></select>
 	</div>

--- a/language.js
+++ b/language.js
@@ -186,34 +186,40 @@ document.addEventListener('DOMContentLoaded', () => {
 		elTime.ariaLabel = languages[lang].txttime;
 	}
 
-	// New game button (top panel, all dialogs).
-	const elsNewGame = document.getElementsByClassName('newGame');
-	for (const elNewGame of elsNewGame) {
-		elNewGame.innerText = languages[lang].btnnewgame;
+	// New game button (top panel).
+	const elNewGameVH = document.querySelector('.newGame .visually-hidden');
+	if (elNewGameVH instanceof HTMLElement) {
+		elNewGameVH.innerText = languages[lang].btnnewgame;
 	}
 
 	// Help button (top panel).
-	const elHelpButton = document.getElementById('helpButton');
+	const elHelpButton = document.querySelector('#helpButton .visually-hidden');
 	if (elHelpButton instanceof HTMLElement) {
 		elHelpButton.innerText = languages[lang].btnhelp;
 	}
 
 	// Highlight button (top panel)
-	const elHighlightButton = document.getElementById('beginnerButton');
+	const elHighlightButton = document.querySelector('#beginnerButton .visually-hidden');
 	if (elHighlightButton instanceof HTMLElement) {
 		elHighlightButton.innerText = languages[lang].btnhighlight;
 	}
 
 	// Highlight button (top panel)
-	const elUndoButton = document.getElementById('undoButton');
+	const elUndoButton = document.querySelector('#undoButton .visually-hidden');
 	if (elUndoButton instanceof HTMLElement) {
 		elUndoButton.innerText = languages[lang].btnundo;
 	}
 
 	// Highlight button (top panel)
-	const elRedoButton = document.getElementById('redoButton');
+	const elRedoButton = document.querySelector('#redoButton .visually-hidden');
 	if (elRedoButton instanceof HTMLElement) {
 		elRedoButton.innerText = languages[lang].btnredo;
+	}
+
+	// New game button (all dialogs).
+	const elsNewGame = document.querySelectorAll('.newGame:not(:has(span))');
+	for (const elNewGame of elsNewGame) {
+		elNewGame.innerText = languages[lang].btnnewgame;
 	}
 
 	// Close button (all dialogs).

--- a/language.js
+++ b/language.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			btnhelp: 'Help',
 			btnclose: 'Close',
 			btnhighlight: 'Highlight',
+			btnreshuffle: 'Reshuffle',
 			btnundo: 'Undo',
 			btnredo: 'Redo',
 			hdgwin: 'You won!',
@@ -75,6 +76,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			btnhelp: 'Nápověda',
 			btnclose: 'Zavřít',
 			btnhighlight: 'Zvýraznění',
+			btnreshuffle: 'Zamíchat',
 			btnundo: 'Zpět',
 			btnredo: 'Vpřed',
 			hdgwin: 'Vyhráli jste!',
@@ -202,6 +204,12 @@ document.addEventListener('DOMContentLoaded', () => {
 	const elHighlightButton = document.querySelector('#beginnerButton .visually-hidden');
 	if (elHighlightButton instanceof HTMLElement) {
 		elHighlightButton.innerText = languages[lang].btnhighlight;
+	}
+
+	// Highlight button (top panel)
+	const elReshuffleButton = document.querySelector('#reshuffleButton .visually-hidden');
+	if (elReshuffleButton instanceof HTMLElement) {
+		elReshuffleButton.innerText = languages[lang].btnreshuffle;
 	}
 
 	// Highlight button (top panel)

--- a/script.js
+++ b/script.js
@@ -477,6 +477,26 @@ document.addEventListener('DOMContentLoaded', () => {
 	};
 
 	/**
+	 * Reshuffles existing tiles (i.e. randomly redistribute their symbols).
+	 * 
+	 * @returns {void}
+	 */
+	const reshuffle = () => {
+		const elsTile = document.getElementsByClassName('tile');
+		let currentIndex = elsTile.length;
+		while (currentIndex != 0) {
+			const randomIndex = Math.floor(Math.random() * currentIndex);
+			currentIndex--;
+			const tmpText = elsTile[currentIndex].innerText;
+			const tmpType = elsTile[currentIndex].dataset.t;
+			elsTile[currentIndex].innerText = elsTile[randomIndex].innerText;
+			elsTile[currentIndex].dataset.t = elsTile[randomIndex].dataset.t;
+			elsTile[randomIndex].innerText = tmpText;
+			elsTile[randomIndex].dataset.t = tmpType;
+		}
+	}
+
+	/**
 	 * Handler for a tile's "click" event.
 	 * 
 	 * This toggles the selection of the tile, if it's not blocked and it's the first selected tile.
@@ -615,6 +635,11 @@ document.addEventListener('DOMContentLoaded', () => {
 			elBeginnerButton.addEventListener('click', () => {
 				toggleBeginner();
 			});
+		}
+
+		const elReshuffleButton = document.getElementById('reshuffleButton');
+		if (elReshuffleButton instanceof EventTarget) {
+			elReshuffleButton.addEventListener('click', reshuffle);
 		}
 
 		const elUndoButton = document.getElementById('undoButton');

--- a/script.js
+++ b/script.js
@@ -757,11 +757,25 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		}
 
-		const dealStringParam = new URL(location.href).searchParams.get('deal');
-		let tileTypesLocal = tileTypes;
-		shuffle(tileTypesLocal);
-		let dealStringRandom = tileTypesLocal.toString().replaceAll(',','');
-		let dealString = dealStringParam ?? dealStringRandom;
+		let dealStringParam = new URL(location.href).searchParams.get('deal');
+		if ((typeof dealStringParam === 'string' || (dealStringParam instanceof String)) &&
+		    dealStringParam.length === 292
+		) {
+			for (const c of dealStringParam) {
+				if (c.codePointAt(0) !== 65038 && c !== '🀄' && tileTypes.indexOf(c) < 0) {
+					dealStringParam = null;
+					break;
+				}
+			}
+		} else {
+			dealStringParam = null;
+		}
+		let dealString = dealStringParam;
+		if (dealString === null) {
+			let tileTypesLocal = tileTypes;
+			shuffle(tileTypesLocal);
+			dealString = tileTypesLocal.toString().replaceAll(',','');
+		}
 		console.log('Deal string:', dealString);
 
 		for (const tileShape of shapeDef) {

--- a/script.js
+++ b/script.js
@@ -109,6 +109,13 @@ document.addEventListener('DOMContentLoaded', () => {
 	};
 
 	/**
+	 * Contains references to open tiles grouped by their symbols. Used by tile highlighting.
+	 * 
+	 * @var {Object.<string,Array.<HTMLElement>>}
+	 */
+	let markPairs = {};
+
+	/**
 	 * Checks whether the player still has some tiles to match. If not, it does not let them suffer
 	 * anymore and closes the game right away, showing the "You lost" dialog.
 	 * 
@@ -295,7 +302,17 @@ document.addEventListener('DOMContentLoaded', () => {
 			tile.classList.add('freeBottom');
 		}
 		if (isBeginner() && !isBlocked(tile)) {
-			tile.classList.add('notBlocked');
+			let markSymbol = tile.innerText;
+			if (flowers.indexOf(markSymbol) > -1) {
+				markSymbol = 'f';
+			}
+			if (seasons.indexOf(markSymbol) > -1) {
+				markSymbol = 's';
+			}
+			if (markPairs[markSymbol] === undefined) {
+				markPairs[markSymbol] = [];
+			}
+			markPairs[markSymbol].push(tile);
 		}
 	}
 
@@ -305,9 +322,18 @@ document.addEventListener('DOMContentLoaded', () => {
 	 * @return {void}
 	 */
 	const markFreeSidesForAll = () => {
+		markPairs = {};
 		const elsTile = document.getElementsByClassName('tile');
 		for (const elTile of elsTile) {
 			markFreeSides(elTile);
+		}
+		for (const markPair of Object.getOwnPropertyNames(markPairs)) {
+			if (markPairs[markPair].length < 2) {
+				continue;
+			}
+			for (const markTile of markPairs[markPair]) {
+				markTile.classList.add('notBlocked');
+			}
 		}
 	}
 

--- a/script.js
+++ b/script.js
@@ -667,7 +667,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		const screenWidth = visualViewport.width;
 		const screenHeight = (visualViewport.height - elPanel.clientHeight); 
 
-		const shapeRatio = (parseInt(sessionStorage.getItem('shapew')) / parseInt(sessionStorage.getItem('shapeh')));
+		const shapeRatio = (parseInt(sessionStorage.getItem('shapew')) / parseInt(sessionStorage.getItem('shapeh'))) * (6.9/9);
 		const screenRatio = (screenWidth / screenHeight);
 
 		let tileH = 0;

--- a/style.css
+++ b/style.css
@@ -35,7 +35,7 @@ button:not(:focus):not(:hover):not(:active) .visually-hidden {
 }
 button:hover .visually-hidden {
 	display: block;
-	border: 1px solid #000;
+	border: 0.1vw solid #000;
 	background-color: #fff;
 	position: absolute;
 	left: 0px;
@@ -44,8 +44,8 @@ button:hover .visually-hidden {
 	white-space: nowrap;
 	font-size: 125%;
 	padding: 0.25rem 0.5rem;
-	margin-left: -2px;
-	margin-top: 1px;
+	margin-left: -0.15vw;
+	margin-top: 0.1vw;
 }
 
 /* Board */
@@ -62,9 +62,9 @@ button:hover .visually-hidden {
 
 .tile {
 	position: relative;
-	border: 1px solid #aaa;
-	border-radius: 5px;
-	box-shadow: 1px 1px #777, 2px 2px #777, 3px 3px #777, 4px 4px #000;
+	border: 0.1vw solid #aaa;
+	border-radius: 8%;
+	box-shadow: 0.1vw 0.1vw #777, 0.15vw 0.15vw #777, 0.2vw 0.2vw #777, 0.25vw 0.25vw #000;
 	background-color: white;
 	display: flex;
 	justify-content: center;
@@ -92,19 +92,19 @@ button:hover .visually-hidden {
 }
 .tile.freeTop {
 	border-top-color: #000;
-	border-top-width: 2px;
+	border-top-width: 0.15vw;
 }
 .tile.freeBottom {
 	border-bottom-color: #000;
-	border-bottom-width: 2px;
+	border-bottom-width: 0.15vw;
 }
 .tile.freeLeft {
 	border-left-color: #000;
-	border-left-width: 2px;
+	border-left-width: 0.15vw;
 }
 .tile.freeRight {
 	border-right-color: #000;
-	border-right-width: 2px;
+	border-right-width: 0.15vw;
 }
 .tile.z1 {
 	background-color: #bbb;
@@ -137,12 +137,12 @@ button:hover .visually-hidden {
 	background-color: #bfb;
 }
 .tile:hover {
-	border: 2px solid #f0f;
-	box-shadow: 1px 1px #f0f, 2px 2px #f0f, 3px 3px #f0f, 4px 4px #f0f;
+	border: 0.15vw solid #f0f;
+	box-shadow: 0.1vw 0.1vw #f0f, 0.15vw 0.15vw #f0f, 0.2vw 0.2vw #f0f, 0.25vw 0.25vw #f0f;
 }
 .tile[data-s="selected"] {
-	border: 2px solid #f00;
-	box-shadow: 1px 1px #f00, 2px 2px #f00, 3px 3px #f00, 4px 4px #f00;
+	border: 0.15vw solid #f00;
+	box-shadow: 0.1vw 0.1vw #f00, 0.15vw 0.15vw #f00, 0.2vw 0.2vw #f00, 0.25vw 0.25vw #f00;
 }
 
 /* Top Panel */
@@ -151,6 +151,7 @@ button:hover .visually-hidden {
 	background-color: rgba(255,255,255,0.75);
 	display: flex;
 	justify-content: center;
+	align-items: center;
 	column-gap: 1rem;
 	padding: 0.25rem 0.5rem;
 	font-size: 125%;
@@ -159,7 +160,10 @@ button:hover .visually-hidden {
 	text-decoration: none;
 }
 #language-switcher {
-	padding: 0 0.25rem;
+	padding: 0.2rem 0.4rem;
+}
+#points, #time {
+	white-space: nowrap;
 }
 #points::before {
 	content: "🏆";
@@ -177,7 +181,7 @@ button:hover .visually-hidden {
 	position: absolute;
 	bottom: 0;
 	right: 0;
-	border: 1px solid black;
+	border: 0.1vw solid black;
 	border-radius: 10%;
 	background-color: #fff;
 	display: flex;
@@ -209,15 +213,9 @@ button:hover .visually-hidden {
 	margin: auto;
 	background-color: #fff;
 	padding: 1rem 2rem;
-	border: 2px solid black;
+	border: 0.15vw solid black;
 	border-radius: 1rem;
 	max-width: 50%;
-}
-@media (max-width: 1094px) {
-	.gamedlg {
-		max-width: 90%;
-		padding: 0.5rem 1rem;
-	}
 }
 .dlgmessage {
 	display: flex;
@@ -232,15 +230,52 @@ button:hover .visually-hidden {
 	column-gap: 1rem;
 	margin-top: 1rem;
 }
-@media (max-width: 1094px) {
-	.dlgbuttons {
-		margin-top: 0.5rem;
-	}
-}
 .dlgheading {
 	font-size: 125%;
 	font-weight: bold;
 }
 .dlgsmiley {
 	font-size: 300%;
+}
+
+/* Small screens */
+
+@media (max-width: 768px) or (max-height: 400px) {
+	button {
+		padding: 0.125rem 0.25rem;
+	}
+	button:hover .visually-hidden {
+		padding: 0.125rem 0.25rem;
+	}
+	.gamedlg {
+		max-width: 90%;
+		padding: 0.5rem 1rem;
+	}
+	.dlgbuttons {
+		margin-top: 0.5rem;
+	}
+	#language-switcher {
+		padding: 0 0.25rem;
+	}
+	#current {
+		padding: 0.125rem 0.25rem;
+		border-radius: 5%;
+	}
+	#currentimg {
+		font-size: 200%;
+	}
+	.dlgheading {
+		font-size: 100%;
+		font-weight: bold;
+	}
+	.dlgsmiley {
+		font-size: 200%;
+	}
+	.panel {
+		font-size: 100%;
+		padding: 0.125rem 0.25rem;
+	}
+	button:hover .visually-hidden {
+		font-size: 100%;
+	}
 }

--- a/style.css
+++ b/style.css
@@ -95,8 +95,20 @@ button {
 .tile.z5 {
 	background-color: #fff;
 }
-.tile.notBlocked {
+.tile.z1.notBlocked {
+	background-color: #7f7;
+}
+.tile.z2.notBlocked {
+	background-color: #8f8;
+}
+.tile.z3.notBlocked {
 	background-color: #9f9;
+}
+.tile.z4.notBlocked {
+	background-color: #afa;
+}
+.tile.z5.notBlocked {
+	background-color: #bfb;
 }
 .tile:hover {
 	border: 2px solid #f0f;

--- a/style.css
+++ b/style.css
@@ -21,6 +21,31 @@ body {
 
 button {
 	padding: 0.25rem 0.5rem;
+	position: relative;
+}
+
+button:not(:focus):not(:hover):not(:active) .visually-hidden {
+	clip: rect(0 0 0 0); 
+	clip-path: inset(100%); 
+	height: 1px; 
+	overflow: hidden; 
+	position: absolute; 
+	white-space: nowrap; 
+	width: 1px; 
+}
+button:hover .visually-hidden {
+	display: block;
+	border: 1px solid #000;
+	background-color: #fff;
+	position: absolute;
+	left: 0px;
+	top: 100%;
+	z-index: 999;
+	white-space: nowrap;
+	font-size: 125%;
+	padding: 0.25rem 0.5rem;
+	margin-left: -2px;
+	margin-top: 1px;
 }
 
 /* Board */

--- a/style.css
+++ b/style.css
@@ -12,6 +12,7 @@
 }
 
 body {
+	background-color: #0c0f0b;
 	background-image: url('background.webp');
 	background-repeat: no-repeat;
 	background-size: cover;


### PR DESCRIPTION
- :new: Reshuffle (#25)
- :hammer_and_pick: Only tiles that can be matched will be highlighted (#24)
- :hammer_and_pick: Highlighted tiles are also shaded based on their z-index (#22)
- :hammer_and_pick: When providing the app with prepared deal string via URL query var `deal`, the value must consist of exactly 144 Mahjongg card symbols (#21)
- :hammer_and_pick: When comparing the width:height ratio of the deal shape and the viewport, tile ratio is also taken into consideration (#23)
- :hammer_and_pick: Body background color is set to a similar color appearing at the bottom of the background image (#26)
- :hammer_and_pick: Buttons on the top panel use icons instead of texts (#27)
- :hammer_and_pick: Borders, shadows, fonts, paddings etc. are adjusted when a small screen is detected (#9)
